### PR TITLE
Replace `Arc` usage with direct ownership in llm, tools, toolset and session services

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ use radkit::a2a::{
 use radkit::agents::{Agent, AgentConfig};
 use radkit::models::AnthropicLlm;
 use radkit::sessions::InMemorySessionService;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -48,10 +47,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenvy::dotenv()?;
 
     // Create an LLM provider (supports Anthropic, Gemini, and Mock providers)
-    let llm = Arc::new(AnthropicLlm::new(
+    let llm = AnthropicLlm::new(
         "claude-3-5-sonnet-20241022".to_string(),
         std::env::var("ANTHROPIC_API_KEY")?,
-    ));
+    );
 
     // Create an agent using the builder pattern with built-in task management tools
     let agent = Agent::builder(
@@ -59,8 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
          always use update_status to indicate your progress (e.g., 'working' \
          when processing, 'completed' when done). When you produce any \
          results or findings, save them using save_artifact so they can be \
-         retrieved later."
-            .to_string(),
+         retrieved later.",
         llm,
     )
     .with_card(|c| {
@@ -68,9 +66,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_description("Research Assistant")
     })
     .with_config(AgentConfig::default().with_max_iterations(10))
-    .with_session_service(Arc::new(InMemorySessionService::new()))
+    .with_session_service(InMemorySessionService::new())
     .with_builtin_task_tools() // Enables update_status and save_artifact tools
-    .build()?;
+    .build();
 
     // User simply asks for research - no mention of tools
     let message = Message {

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -45,7 +45,6 @@ use radkit::a2a::{
 };
 use radkit::agents::{Agent, AgentConfig};
 use radkit::models::AnthropicLlm;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -53,27 +52,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenvy::dotenv()?;
 
     // Create an LLM provider (supports Anthropic, Gemini, and Mock providers)
-    let llm = Arc::new(AnthropicLlm::new(
+    let llm = AnthropicLlm::new(
         "claude-3-5-sonnet-20241022".to_string(),
         std::env::var("ANTHROPIC_API_KEY")?,
-    ));
+    );
 
     // Create an agent with built-in task management tools
     let agent = Agent::builder(
         "You are a helpful research assistant. When working on tasks,
-        \
-         always use update_status to indicate your progress (e.g., 'working' \
-         when processing, 'completed' when done,
-    )
-    .with_card(|c| c.with_name("research_assistant".to_string()).with_description("Research Assistant".to_string()))
-    .build(). When you produce any \
-         results or findings, save them using save_artifact so they can be \
-         retrieved later."
-            .to_string(),
+        always use update_status to indicate your progress (e.g., 'working' when processing, 'completed' when done.
+        When you produce any results or findings, save them using save_artifact so they can be retrieved later.",
         llm,
     )
         .with_config(AgentConfig::default().with_max_iterations(10))
-        .with_builtin_task_tools(); // Enables update_status and save_artifact tools
+        .with_builtin_task_tools() // Enables update_status and save_artifact tools
+        .build();
 
     // User simply asks for research - no mention of tools
     let message = Message {

--- a/radkit/tests/anthropic_simple.rs
+++ b/radkit/tests/anthropic_simple.rs
@@ -21,7 +21,7 @@ fn create_test_agent() -> Option<Agent> {
     init_test_env();
     get_anthropic_key().map(|api_key| {
         let anthropic_llm = AnthropicLlm::new("claude-3-5-sonnet-20241022".to_string(), api_key);
-        let session_service = Arc::new(InMemorySessionService::new());
+        let session_service = InMemorySessionService::new();
 
         Agent::builder(
             "You are a helpful assistant. Respond briefly and clearly.",

--- a/radkit/tests/event_storage_integration.rs
+++ b/radkit/tests/event_storage_integration.rs
@@ -230,7 +230,7 @@ async fn test_tool_event_storage() -> AgentResult<()> {
     );
 
     let mock_llm = MockLlm::new("test-model".to_string());
-    let tool: Arc<dyn radkit::tools::BaseTool> = Arc::new(calculator_tool);
+    let tool = calculator_tool;
     let agent = Agent::builder(
         "You are a helpful assistant with calculation tools.",
         mock_llm,

--- a/radkit/tests/gemini_tool_use.rs
+++ b/radkit/tests/gemini_tool_use.rs
@@ -16,14 +16,9 @@ mod common;
 use common::get_gemini_key;
 
 /// Helper function to create Agent with Gemini if API key is available
-fn create_test_agent_with_tools(tools: Vec<Arc<FunctionTool>>) -> Option<Agent> {
+fn create_test_agent_with_tools(tools: Vec<FunctionTool>) -> Option<Agent> {
     get_gemini_key().map(|api_key| {
         let gemini_llm = GeminiLlm::new("gemini-2.0-flash-exp".to_string(), api_key);
-
-        let base_tools: Vec<Arc<dyn radkit::tools::BaseTool>> = tools
-            .into_iter()
-            .map(|tool| tool as Arc<dyn radkit::tools::BaseTool>)
-            .collect();
 
         Agent::builder(
             "You are a helpful assistant. Use the available tools when requested by the user.",
@@ -33,7 +28,7 @@ fn create_test_agent_with_tools(tools: Vec<Arc<FunctionTool>>) -> Option<Agent> 
             c.with_name("test_agent")
                 .with_description("Test agent for Gemini function calling")
         })
-        .with_tools(base_tools)
+        .with_tools(tools)
         .build()
     })
 }
@@ -99,7 +94,7 @@ fn create_weather_tool() -> FunctionTool {
 #[tokio::test]
 #[ignore] // Only run with --ignored flag when API key is available
 async fn test_gemini_single_function_call() {
-    let Some(agent) = create_test_agent_with_tools(vec![Arc::new(create_weather_tool())]) else {
+    let Some(agent) = create_test_agent_with_tools(vec![create_weather_tool()]) else {
         println!("⚠️  Skipping test: GEMINI_API_KEY not found");
         return;
     };

--- a/radkit/tests/mcp_weather_simple.rs
+++ b/radkit/tests/mcp_weather_simple.rs
@@ -42,7 +42,7 @@ fn create_mcp_weather_toolset() -> MCPToolset {
 fn create_anthropic_weather_agent() -> Option<Agent> {
     get_anthropic_key().map(|api_key| {
         let anthropic_llm = AnthropicLlm::new("claude-3-5-sonnet-20241022".to_string(), api_key);
-        let session_service = Arc::new(InMemorySessionService::new());
+        let session_service = InMemorySessionService::new();
         let mcp_toolset = create_mcp_weather_toolset();
 
         Agent::builder(
@@ -63,7 +63,7 @@ fn create_anthropic_weather_agent() -> Option<Agent> {
 fn create_gemini_weather_agent() -> Option<Agent> {
     get_gemini_key().map(|api_key| {
         let gemini_llm = GeminiLlm::new("gemini-2.0-flash-exp".to_string(), api_key);
-        let session_service = Arc::new(InMemorySessionService::new());
+        let session_service = InMemorySessionService::new();
         let mcp_toolset = create_mcp_weather_toolset();
 
         Agent::builder(
@@ -85,7 +85,7 @@ fn create_openai_weather_agent() -> Option<Agent> {
     init_test_env();
     get_openai_key().map(|api_key| {
         let openai_llm = OpenAILlm::new("gpt-4o-mini".to_string(), api_key);
-        let session_service = Arc::new(InMemorySessionService::new());
+        let session_service = InMemorySessionService::new();
         let mcp_toolset = create_mcp_weather_toolset();
 
         Agent::builder(

--- a/radkit/tests/openai_simple.rs
+++ b/radkit/tests/openai_simple.rs
@@ -23,7 +23,7 @@ fn create_test_agent() -> Option<Agent> {
     init_test_env();
     get_openai_key().map(|api_key| {
         let openai_llm = OpenAILlm::new("gpt-4o-mini".to_string(), api_key);
-        let session_service = Arc::new(InMemorySessionService::new());
+        let session_service = InMemorySessionService::new();
 
         Agent::builder(
             "You are a helpful assistant. Respond briefly and clearly.",


### PR DESCRIPTION
Refactor: Replace `Arc` usage with direct ownership in llm, tools, toolsets, and session services

- Transition from `Arc` to direct ownership (`Box`) for tools and session services
- Simplify toolset creation and management
- Update documentation and examples to reflect ownership model changes
- Adjust tests for updated APIs, ensuring compatibility and proper integration