### PR TITLE
feat: Add production-ready OpenTelemetry observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +48,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "async-stream"
@@ -87,19 +102,47 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.3.4",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 0.1.2",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "axum-macros",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -112,12 +155,29 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -129,13 +189,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -169,15 +229,36 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -244,10 +325,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -299,6 +408,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +439,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -472,6 +597,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +640,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.11.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,13 +675,19 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
- "indexmap",
+ "http 1.3.1",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -537,6 +703,17 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -548,12 +725,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -564,8 +752,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -583,6 +771,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
@@ -591,9 +803,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -610,8 +822,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.3.1",
+ "hyper 1.7.0",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -622,6 +834,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.32",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,7 +853,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -643,19 +867,19 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -802,6 +1026,16 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
@@ -816,7 +1050,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -835,6 +1069,15 @@ checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -900,6 +1143,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,7 +1212,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1005,7 +1257,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1044,6 +1296,117 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 0.2.12",
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bdf28b381f23afcd150afc0b38a4183dd321fc96320c1554752b6b761648f78"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "ordered-float",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float",
+ "percent-encoding",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1440,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1130,11 +1513,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
 dependencies = [
  "futures",
- "indexmap",
+ "indexmap 2.11.0",
  "nix",
  "tokio",
  "tracing",
  "windows",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1150,8 +1556,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
- "thiserror",
+ "socket2 0.6.0",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "web-time",
@@ -1166,13 +1572,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.16",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1187,7 +1593,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1217,15 +1623,26 @@ dependencies = [
  "dashmap",
  "dotenvy",
  "futures",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
+ "regex",
  "reqwest",
  "rmcp",
  "serde",
  "serde_json",
- "thiserror",
+ "sha2",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tonic",
  "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -1235,25 +1652,41 @@ version = "0.0.1"
 dependencies = [
  "a2a-types",
  "async-trait",
- "axum",
- "base64",
+ "axum 0.7.9",
+ "base64 0.22.1",
  "chrono",
  "futures",
- "hyper",
+ "hyper 1.7.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "pin-project-lite",
  "radkit",
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
  "tokio-test",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1262,8 +1695,18 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1273,7 +1716,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1291,7 +1743,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -1315,21 +1767,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
 name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -1345,12 +1826,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -1381,10 +1862,10 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7dd163d26e254725137b7933e4ba042ea6bf2d756a4260559aaea8b6ad4c27e"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "futures",
- "http",
+ "http 1.3.1",
  "paste",
  "pin-project-lite",
  "process-wrap",
@@ -1394,7 +1875,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1432,7 +1913,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1533,7 +2014,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1616,6 +2097,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +2145,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -1669,7 +2171,7 @@ checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
 dependencies = [
  "bytes",
  "futures-util",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
 ]
@@ -1705,6 +2207,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -1729,7 +2237,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -1759,11 +2267,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.16",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1826,9 +2354,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.6.0",
  "tokio-macros",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1901,6 +2439,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.6.20",
+ "base64 0.21.7",
+ "bytes",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,7 +2494,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -1922,14 +2507,14 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1992,17 +2577,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2010,6 +2630,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
@@ -2034,6 +2660,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -2064,6 +2696,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -2486,7 +3124,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -165,6 +165,52 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 - **A2A Events**: Automatic generation of protocol-compliant events
 - **Built-in Tools**: `update_status` and `save_artifact` with event emission
 
+### Production-Ready Observability
+- **OpenTelemetry Native**: Industry-standard distributed tracing and metrics
+- **Seamless Integration**: Works with your existing observability stack (Jaeger, Zipkin, Datadog, etc.)
+- **W3C Trace Context**: Automatic trace propagation across service boundaries
+- **4 Integration Patterns**: Standalone, embedded library, multi-agent, or use parent's telemetry
+- **Full Instrumentation**: Agent calls, LLM requests, tool executions, conversation loops
+- **PII Protection**: GDPR-compliant user ID hashing and sensitive data redaction
+- **Cost Tracking**: Built-in LLM cost calculation with configurable pricing
+
+## Observability Integration
+
+RadKit seamlessly integrates with your existing OpenTelemetry setup. If your service already has tracing configured, RadKit will automatically continue those traces:
+
+```rust
+// Your existing service with OpenTelemetry
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Your existing OpenTelemetry setup
+    let tracer = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(opentelemetry_otlp::new_exporter().tonic())
+        .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+
+    // Configure RadKit to use your existing telemetry (Pattern 4)
+    radkit::observability::configure_radkit_telemetry(
+        radkit::observability::TelemetryConfig {
+            backend: radkit::observability::TelemetryBackend::UseGlobal,
+            redact_pii: true,
+            ..Default::default()
+        }
+    )?;
+
+    // Now all RadKit operations appear in your existing traces!
+    let agent = Agent::builder("You are helpful", llm).build();
+
+    // This will be a child span of any active trace in your service
+    agent.send_message(app, user, params).await?;
+
+    Ok(())
+}
+```
+
+**Result:** Your service → RadKit agent → LLM calls all appear as one distributed trace with the same trace ID.
+
+For more details, see the observability documentation in [`radkit/README.md`](radkit/README.md#production-observability).
+
 ## Quick Start Guide
 
 <div id="centered-install-tabs" class="install-command-container" markdown="1">

--- a/radkit-axum/Cargo.toml
+++ b/radkit-axum/Cargo.toml
@@ -43,4 +43,10 @@ tokio-test = "0.4"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 tower = { version = "0.5", features = ["util"] }
 base64 = "0.22"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# OpenTelemetry for observability example
+opentelemetry = "0.22"
+opentelemetry_sdk = { version = "0.22", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.15", features = ["tokio", "grpc-tonic"] }
+opentelemetry-http = "0.11"
+tracing-opentelemetry = "0.23"

--- a/radkit-axum/README.md
+++ b/radkit-axum/README.md
@@ -161,11 +161,226 @@ curl -X POST http://localhost:3000/message/send \
   }'
 ```
 
+## Observability Integration
+
+RadKit-Axum seamlessly integrates with your existing OpenTelemetry setup, providing full distributed tracing across HTTP requests, agent operations, and LLM calls.
+
+### Automatic Trace Propagation
+
+When you set up OpenTelemetry for your Axum server, RadKit automatically continues those traces:
+
+```rust
+use radkit_axum::A2AServer;
+use radkit::observability::{configure_radkit_telemetry, TelemetryConfig, TelemetryBackend};
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::Resource;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Setup OpenTelemetry for your Axum server
+    let tracer = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(
+            opentelemetry_otlp::new_exporter()
+                .tonic()
+                .with_endpoint("http://localhost:4317")
+        )
+        .with_trace_config(
+            opentelemetry_sdk::trace::config().with_resource(Resource::new(vec![
+                KeyValue::new("service.name", "my-a2a-server"),
+            ]))
+        )
+        .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+
+    let telemetry_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    tracing_subscriber::registry()
+        .with(telemetry_layer)
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    // 2. Configure RadKit to use your OpenTelemetry setup
+    // Note: When using UseGlobal, set service.name on the tracer (above), not here
+    configure_radkit_telemetry(TelemetryConfig {
+        backend: TelemetryBackend::UseGlobal,  // Use parent's telemetry
+        redact_pii: true,
+        ..Default::default()
+    })?;
+
+    // 3. Create your RadKit agent
+    let agent = Agent::builder("You are helpful", llm)
+        .with_builtin_task_tools()
+        .build();
+
+    // 4. Start A2A server - all traces automatically connected!
+    let server = A2AServer::builder(agent).build();
+    server.serve("0.0.0.0:3000").await?;
+
+    Ok(())
+}
+```
+
+### What You Get
+
+**Complete Distributed Trace:**
+```
+HTTP Request (client)
+  └─ POST /message/send (axum handler)
+     └─ radkit.agent.send_message
+        └─ radkit.conversation.execute_core
+           ├─ radkit.llm.generate_content (Anthropic Claude)
+           │  └─ HTTP POST https://api.anthropic.com
+           └─ radkit.tools.process_calls
+              └─ radkit.tool.execute_call (update_status)
+```
+
+**All with the same trace ID!**
+
+### Adding HTTP Trace Context Extraction (Optional)
+
+For incoming HTTP requests with trace context headers, add middleware to extract them:
+
+```rust
+use axum::{middleware, Router};
+use opentelemetry::propagation::TextMapPropagator;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+
+async fn trace_extractor_middleware(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    // Extract W3C Trace Context from HTTP headers
+    let propagator = TraceContextPropagator::new();
+    let parent_context = propagator.extract(&opentelemetry_http::HeaderExtractor(req.headers()));
+
+    // Attach parent context for this request scope
+    let _guard = parent_context.attach();
+
+    // Continue processing - all spans will be children of incoming trace
+    next.run(req).await
+}
+
+// Add to your A2A server
+let server = A2AServer::builder(agent)
+    .with_middleware(middleware::from_fn(trace_extractor_middleware))
+    .build();
+```
+
+Now external clients can send trace context:
+```bash
+curl -X POST http://localhost:3000/message/send \
+  -H 'traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"message/send","params":{...},"id":1}'
+```
+
+And your traces will continue from the client's trace ID!
+
+### Metrics and Cost Tracking
+
+Every request automatically records:
+
+**Metrics:**
+- `radkit.agent.messages` - Messages processed by agent/role
+- `radkit.llm.tokens` - Token usage by model
+- `radkit.tool.executions` - Tool executions by name/success
+
+**Span Attributes:**
+- LLM provider, model, token counts, cost per request
+- Agent name, user ID (hashed), session ID
+- Tool names, durations, success rates
+- Error messages and status codes
+
+### Viewing Traces
+
+Send traces to any OpenTelemetry backend:
+
+**Jaeger:**
+```rust
+let tracer = opentelemetry_jaeger::new_agent_pipeline()
+    .with_service_name("my-a2a-server")
+    .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+```
+
+**Zipkin:**
+```rust
+let tracer = opentelemetry_zipkin::new_pipeline()
+    .with_service_name("my-a2a-server")
+    .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+```
+
+**Datadog, Honeycomb, New Relic, etc.:**
+```rust
+let tracer = opentelemetry_otlp::new_pipeline()
+    .tracing()
+    .with_exporter(
+        opentelemetry_otlp::new_exporter()
+            .tonic()
+            .with_endpoint("https://your-backend.com:4317")
+    )
+    .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+```
+
+### Security & Privacy
+
+**PII Protection:**
+```rust
+configure_radkit_telemetry(TelemetryConfig {
+    redact_pii: true,  // User IDs are SHA256 hashed
+    ..Default::default()
+})?;
+```
+
+**Trusted A2A Trace Propagation:**
+```rust
+configure_radkit_telemetry(TelemetryConfig {
+    trusted_trace_sources: ["agent-a", "agent-b"].iter().map(|s| s.to_string()).collect(),
+    reject_untrusted_traces: true,  // Only accept traces from trusted agents
+    ..Default::default()
+})?;
+```
+
+### Complete Example
+
+See `examples/observability_server.rs` for a complete working example with:
+- OpenTelemetry OTLP export to Jaeger
+- HTTP trace context extraction
+- Cost tracking configuration
+- Multi-tenant support
+
+1. Run Jaeger locally
+```bash
+docker run -d --name jaeger \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  jaegertracing/all-in-one:latest
+```
+
+2. Run the example
+```bash
+cargo run --example observability_server
+```
+
+3. Send a request:
+```bash
+curl -X POST http://localhost:3000/message/send \
+  -H 'X-App-Name: myapp' \
+  -H 'X-User-Id: user1' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"message/send","params":{"message":{"role":"user","messageId":"1","parts":[{"kind":"text","text":"Hello!"}]}},"id":1}'
+```
+
+4. View traces at http://localhost:16686
+
+
 ## Version Compatibility
 
-| radkit-axum | axum  | radkit |
-|-------------|-------|--------|
-| 0.1.x       | 0.7.x | 0.1.x  |
+| radkit-axum | axum  | radkit | opentelemetry |
+|-------------|-------|--------|---------------|
+| 0.1.x       | 0.7.x | 0.1.x  | 0.22.x        |
 
 ## License
 

--- a/radkit-axum/examples/observability_server.rs
+++ b/radkit-axum/examples/observability_server.rs
@@ -1,0 +1,196 @@
+//! Complete observability example with OpenTelemetry, distributed tracing, and cost tracking
+//!
+//! This example demonstrates:
+//! - OpenTelemetry OTLP export to Jaeger
+//! - Automatic distributed tracing across RadKit operations
+//! - LLM cost tracking with configurable pricing
+//! - Multi-tenant support with PII redaction
+//!
+//! # Running this example
+//!
+//! 1. Start Jaeger:
+//! ```bash
+//! docker run -d --name jaeger \
+//!   -p 16686:16686 \
+//!   -p 4317:4317 \
+//!   jaegertracing/all-in-one:latest
+//! ```
+//!
+//! 2. Run the example:
+//! ```bash
+//! cargo run --example observability_server
+//! ```
+//!
+//! 3. Send a request:
+//! ```bash
+//! curl -X POST http://localhost:3000/message/send \
+//!   -H 'X-App-Name: myapp' \
+//!   -H 'X-User-Id: user1' \
+//!   -H 'Content-Type: application/json' \
+//!   -d '{"jsonrpc":"2.0","method":"message/send","params":{"message":{"role":"user","messageId":"1","parts":[{"kind":"text","text":"Hello!"}]}},"id":1}'
+//! ```
+//!
+//! 4. View traces at http://localhost:16686
+
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::Resource;
+use radkit::agents::Agent;
+use radkit::models::MockLlm;
+use radkit::observability::{configure_radkit_telemetry, LlmPricing, TelemetryBackend, TelemetryConfig};
+use radkit_axum::{async_trait, A2AServer, AuthContext, AuthExtractor};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+/// Multi-tenant authentication with app_name and user_id from headers
+#[derive(Clone)]
+struct HeaderAuth;
+
+#[async_trait]
+impl AuthExtractor for HeaderAuth {
+    async fn extract(
+        &self,
+        parts: &mut axum::http::request::Parts,
+    ) -> Result<AuthContext, radkit_axum::auth::AuthError> {
+        // Extract app_name from X-App-Name header
+        let app_name = parts
+            .headers
+            .get("X-App-Name")
+            .and_then(|v| v.to_str().ok())
+            .ok_or(radkit_axum::auth::AuthError::MissingCredentials)?
+            .to_string();
+
+        // Extract user_id from X-User-Id header
+        let user_id = parts
+            .headers
+            .get("X-User-Id")
+            .and_then(|v| v.to_str().ok())
+            .ok_or(radkit_axum::auth::AuthError::MissingCredentials)?
+            .to_string();
+
+        Ok(AuthContext { app_name, user_id })
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Setup OpenTelemetry for your Axum server
+    println!("🔧 Setting up OpenTelemetry...");
+
+    let tracer = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(
+            opentelemetry_otlp::new_exporter()
+                .tonic()
+                .with_endpoint("http://localhost:4317"),
+        )
+        .with_trace_config(
+            opentelemetry_sdk::trace::config().with_resource(Resource::new(vec![
+                KeyValue::new("service.name", "radkit-a2a-server"),
+            ])),
+        )
+        .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+
+    let telemetry_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    tracing_subscriber::registry()
+        .with(telemetry_layer)
+        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_subscriber::EnvFilter::from_default_env().add_directive("radkit=debug".parse()?))
+        .init();
+
+    // 2. Configure RadKit to use your OpenTelemetry setup (Pattern 4)
+    println!("🔧 Configuring RadKit observability...");
+
+    configure_radkit_telemetry(TelemetryConfig {
+        // Note: service_name is set on the tracer above, not here
+        // UseGlobal uses the parent's tracer, so service.name comes from the Resource
+        backend: TelemetryBackend::UseGlobal, // Use parent's telemetry
+        redact_pii: true, // Hash user IDs for GDPR compliance
+        llm_pricing: vec![
+            LlmPricing {
+                model: "mock-model".to_string(),
+                prompt_price: 0.001,      // $0.001 per 1K tokens
+                completion_price: 0.002,  // $0.002 per 1K tokens
+            },
+            LlmPricing {
+                model: "claude-3-5-sonnet-20241022".to_string(),
+                prompt_price: 0.003,
+                completion_price: 0.015,
+            },
+        ],
+        trusted_trace_sources: vec!["trusted-client".to_string()].into_iter().collect(),
+        reject_untrusted_traces: false, // Accept traces from any source for demo
+        ..Default::default()
+    })?;
+
+    // 3. Create your RadKit agent
+    println!("🤖 Creating RadKit agent...");
+
+    let agent = Agent::builder(
+        "You are a helpful AI assistant with full observability.",
+        MockLlm::new("mock-model".to_string()),
+    )
+    .with_card(|card| {
+        card.with_name("Observability Demo Agent")
+            .with_description("Demonstrates OpenTelemetry integration with RadKit")
+            .with_version("1.0.0")
+            .with_url("http://localhost:3000")
+            .with_streaming(true)
+            .add_skill_with("general-help", "General Assistance", |skill| {
+                skill
+                    .with_description("Helps with questions while tracking all operations")
+                    .add_tag("observability")
+                    .add_tag("demo")
+            })
+    })
+    .with_builtin_task_tools()
+    .build();
+
+    // 4. Create A2A server
+    println!("🚀 Starting A2A server with observability...");
+
+    let server = A2AServer::builder(agent)
+        .with_auth(HeaderAuth)
+        .build();
+
+    // Print usage instructions
+    println!("\n✅ Server ready on http://localhost:3000");
+    println!("\n📊 Observability Features:");
+    println!("  • OpenTelemetry traces exported to Jaeger");
+    println!("  • Automatic distributed tracing across RadKit operations");
+    println!("  • LLM cost tracking with configurable pricing");
+    println!("  • PII-safe user ID hashing (SHA256)");
+    println!("  • Multi-tenant support (per app_name)");
+
+    println!("\n🔍 View traces at: http://localhost:16686");
+
+    println!("\n📝 Example request:");
+    println!("  curl -X POST http://localhost:3000/message/send \\");
+    println!("    -H 'X-App-Name: myapp' \\");
+    println!("    -H 'X-User-Id: user123' \\");
+    println!("    -H 'Content-Type: application/json' \\");
+    println!("    -d '{{\"jsonrpc\":\"2.0\",\"method\":\"message/send\",\"params\":{{\"message\":{{\"role\":\"user\", \"messageId\": \"1\", \"parts\":[{{\"kind\":\"text\",\"text\":\"What can you help me with?\"}}]}}}},\"id\":1}}'");
+
+    println!("\n📊 What you'll see in Jaeger:");
+    println!("  • HTTP Request → POST /message/send");
+    println!("  • RadKit Agent → radkit.agent.send_message");
+    println!("  • Conversation → radkit.conversation.execute_core");
+    println!("  • LLM Call → radkit.llm.generate_content");
+    println!("  • Tool Execution → radkit.tools.process_calls");
+    println!("  • All with distributed tracing across the entire flow!");
+
+    println!("\n💡 Tips:");
+    println!("  • Check span attributes for cost, tokens, user_id (hashed)");
+    println!("  • Filter by 'service.name=radkit-a2a-server' in Jaeger");
+    println!("  • Look for 'llm.cost_usd' attribute on LLM spans");
+    println!("  • User IDs are SHA256 hashed for privacy (redact_pii=true)");
+
+    // Start the server
+    server.serve("0.0.0.0:3000").await?;
+
+    // Shutdown OpenTelemetry
+    opentelemetry::global::shutdown_tracer_provider();
+
+    Ok(())
+}

--- a/radkit/Cargo.toml
+++ b/radkit/Cargo.toml
@@ -27,5 +27,18 @@ chrono = { version = "0.4.41", features = ["serde"] }
 dashmap = "6.1.0"
 rmcp = { version = "0.6.3", features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 
+# Observability dependencies
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "registry", "fmt"] }
+tracing-opentelemetry = "0.23.0"
+opentelemetry = "0.22.0"
+opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.15.0", features = ["tokio", "grpc-tonic", "http-proto"] }
+opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry-stdout = { version = "0.3.0", features = ["trace"] }
+tonic = "0.11"
+sha2 = "0.10"
+regex = "1.10"
+once_cell = "1.19"
+
 [dev-dependencies]
 dotenvy = "0.15"

--- a/radkit/README.md
+++ b/radkit/README.md
@@ -79,6 +79,152 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 - Streaming message support
 - Artifact persistence
 
+### Production Observability
+
+RadKit includes comprehensive OpenTelemetry instrumentation that integrates seamlessly with your existing observability stack.
+
+#### Seamless Integration with Existing OpenTelemetry
+
+If your service already uses OpenTelemetry, RadKit automatically continues those traces:
+
+```rust
+use radkit::observability::{configure_radkit_telemetry, TelemetryConfig, TelemetryBackend};
+
+// After your service sets up OpenTelemetry
+opentelemetry::global::set_tracer_provider(your_tracer_provider);
+
+// Configure RadKit to use your existing setup
+configure_radkit_telemetry(TelemetryConfig {
+    backend: TelemetryBackend::UseGlobal,  // Use parent's telemetry
+    redact_pii: true,
+    ..Default::default()
+})?;
+
+// Now all RadKit operations appear in your traces!
+let agent = Agent::builder(instruction, llm).build();
+agent.send_message(app, user, params).await?;  // Traced automatically
+```
+
+#### What Gets Traced
+
+- ✅ **Agent Operations**: send_message, send_streaming_message with user context
+- ✅ **Conversation Loops**: Iteration counts, task IDs, success/error status
+- ✅ **LLM Calls**: Provider, model, token usage, cost per request
+- ✅ **Tool Executions**: Individual tool calls with duration and success rates
+- ✅ **Error Tracking**: Automatic error recording with full context
+
+#### Example: HTTP Service with RadKit
+
+```rust
+use axum::{Router, routing::post};
+use radkit::observability::{configure_radkit_telemetry, TelemetryConfig, TelemetryBackend};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Setup your service's OpenTelemetry
+    let tracer = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(opentelemetry_otlp::new_exporter().tonic())
+        .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+
+    let telemetry_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    tracing_subscriber::registry()
+        .with(telemetry_layer)
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    // 2. Configure RadKit to use your telemetry
+    configure_radkit_telemetry(TelemetryConfig {
+        backend: TelemetryBackend::UseGlobal,
+        redact_pii: true,
+        ..Default::default()
+    })?;
+
+    // 3. Create your agent
+    let agent = Agent::builder("You are helpful", llm).build();
+
+    // 4. HTTP handler - traces automatically connect!
+    let app = Router::new()
+        .route("/chat", post(|body: Json<ChatRequest>| async move {
+            // This span will be a child of the HTTP request span
+            let result = agent.send_message(
+                body.app_name,
+                body.user_id,
+                body.params
+            ).await?;
+
+            Ok(Json(result))
+        }));
+
+    // Now: HTTP request → Agent → LLM → Tools all in one trace!
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+```
+
+#### Trace Propagation
+
+RadKit supports W3C Trace Context propagation across service boundaries:
+
+```rust
+// Sending to another RadKit agent
+use radkit::observability::inject_trace_context;
+
+let message_with_trace = inject_trace_context(a2a_message);
+other_agent.send(message_with_trace).await?;
+
+// Receiving from another agent
+use radkit::observability::extract_trace_context_safe;
+
+let parent_context = extract_trace_context_safe(&message, sender, &config);
+// Your spans become children of the sender's trace
+```
+
+#### Cost Tracking
+
+Built-in LLM cost calculation with configurable pricing:
+
+```rust
+let config = TelemetryConfig {
+    llm_pricing: vec![
+        LlmPricing {
+            model: "claude-3-5-sonnet-20241022".to_string(),
+            prompt_price: 0.003,      // $0.003 per 1K tokens
+            completion_price: 0.015,  // $0.015 per 1K tokens
+        }
+    ],
+    ..Default::default()
+};
+```
+
+Every LLM call automatically records:
+- Token usage (prompt, completion, total)
+- Cost in USD
+- Model and provider
+- Request/response metadata
+
+#### Security & Privacy
+
+- **PII Redaction**: User IDs are SHA256 hashed before tracing
+- **Sensitive Data Sanitization**: API keys, tokens, passwords redacted from tool args
+- **Trusted Sources**: Only accept trace context from whitelisted agents
+
+```rust
+let config = TelemetryConfig {
+    redact_pii: true,
+    trusted_trace_sources: ["agent-a", "api-gateway"].iter().map(|s| s.to_string()).collect(),
+    reject_untrusted_traces: true,
+    ..Default::default()
+};
+```
+
+#### Metrics Available
+
+- `radkit.agent.messages` - Message count by agent and role
+- `radkit.llm.tokens` - Token usage by model
+- `radkit.tool.executions` - Tool execution count and success rate
+
 ## Documentation
 
 For detailed documentation, see the [main README](https://github.com/microagents/radkit).

--- a/radkit/src/lib.rs
+++ b/radkit/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agents;
 pub mod errors;
 pub mod events;
 pub mod models;
+pub mod observability;
 pub mod sessions;
 pub mod tools;
 

--- a/radkit/src/observability/a2a_trace.rs
+++ b/radkit/src/observability/a2a_trace.rs
@@ -1,0 +1,263 @@
+//! A2A Trace Propagation
+//!
+//! This module provides W3C Trace Context propagation across A2A protocol messages.
+//! Uses the Message.metadata field to carry trace context headers.
+
+use a2a_types::Message;
+use opentelemetry::propagation::TextMapPropagator;
+use std::collections::HashMap;
+
+use crate::observability::config::TelemetryConfig;
+
+/// Inject trace context into A2A message metadata
+///
+/// Adds W3C Trace Context (traceparent, tracestate) to message metadata.
+/// The message is modified in-place and returned for convenience.
+///
+/// # Example
+/// ```rust,no_run
+/// use radkit::observability::inject_trace_context;
+/// # use a2a_types::Message;
+///
+/// let message = /* create your message */
+/// # Message {
+/// #     kind: "message".to_string(),
+/// #     message_id: "test".to_string(),
+/// #     role: a2a_types::MessageRole::User,
+/// #     parts: vec![],
+/// #     context_id: None,
+/// #     task_id: None,
+/// #     reference_task_ids: vec![],
+/// #     extensions: vec![],
+/// #     metadata: None,
+/// # };
+/// let message_with_trace = inject_trace_context(message);
+/// ```
+pub fn inject_trace_context(mut message: Message) -> Message {
+    let propagator = opentelemetry_sdk::propagation::TraceContextPropagator::new();
+    let context = opentelemetry::Context::current();
+
+    let mut carrier = HashMap::new();
+    propagator.inject_context(&context, &mut carrier);
+
+    let mut metadata = message.metadata.unwrap_or_default();
+    if let Some(traceparent) = carrier.get("traceparent") {
+        metadata.insert(
+            "traceparent".to_string(),
+            serde_json::Value::String(traceparent.clone()),
+        );
+    }
+    if let Some(tracestate) = carrier.get("tracestate") {
+        metadata.insert(
+            "tracestate".to_string(),
+            serde_json::Value::String(tracestate.clone()),
+        );
+    }
+
+    message.metadata = Some(metadata);
+    message
+}
+
+/// Extract trace context from A2A message metadata
+///
+/// Returns the OpenTelemetry context if trace headers are present.
+///
+/// # Example
+/// ```rust,no_run
+/// use radkit::observability::extract_trace_context;
+/// # use a2a_types::Message;
+///
+/// # let message = Message {
+/// #     kind: "message".to_string(),
+/// #     message_id: "test".to_string(),
+/// #     role: a2a_types::MessageRole::User,
+/// #     parts: vec![],
+/// #     context_id: None,
+/// #     task_id: None,
+/// #     reference_task_ids: vec![],
+/// #     extensions: vec![],
+/// #     metadata: None,
+/// # };
+/// if let Some(parent_context) = extract_trace_context(&message) {
+///     // Use context to create child span
+/// }
+/// ```
+pub fn extract_trace_context(message: &Message) -> Option<opentelemetry::Context> {
+    let metadata = message.metadata.as_ref()?;
+    let traceparent = metadata.get("traceparent")?.as_str()?;
+
+    let mut carrier = HashMap::new();
+    carrier.insert("traceparent".to_string(), traceparent.to_string());
+
+    if let Some(tracestate) = metadata.get("tracestate").and_then(|v| v.as_str()) {
+        carrier.insert("tracestate".to_string(), tracestate.to_string());
+    }
+
+    let propagator = opentelemetry_sdk::propagation::TraceContextPropagator::new();
+    Some(propagator.extract(&carrier))
+}
+
+/// Extract trace context with security checks
+///
+/// Only accepts traces from trusted sources when reject_untrusted_traces is enabled.
+///
+/// # Arguments
+/// * `message` - The A2A message containing trace context
+/// * `sender_agent_name` - The name of the agent that sent this message
+/// * `config` - Telemetry configuration with trust settings
+///
+/// # Security
+/// - If `reject_untrusted_traces` is true and `trusted_trace_sources` is empty, all traces are rejected
+/// - If `reject_untrusted_traces` is true, only traces from whitelisted sources are accepted
+/// - If `reject_untrusted_traces` is false, all traces are accepted
+///
+/// # Example
+/// ```rust,no_run
+/// use radkit::observability::{extract_trace_context_safe, TelemetryConfig};
+/// # use a2a_types::Message;
+/// # use std::collections::HashSet;
+///
+/// let config = TelemetryConfig {
+///     trusted_trace_sources: ["agent-1".to_string()].iter().cloned().collect(),
+///     reject_untrusted_traces: true,
+///     ..Default::default()
+/// };
+///
+/// # let message = Message {
+/// #     kind: "message".to_string(),
+/// #     message_id: "test".to_string(),
+/// #     role: a2a_types::MessageRole::User,
+/// #     parts: vec![],
+/// #     context_id: None,
+/// #     task_id: None,
+/// #     reference_task_ids: vec![],
+/// #     extensions: vec![],
+/// #     metadata: None,
+/// # };
+/// if let Some(context) = extract_trace_context_safe(&message, "agent-1", &config) {
+///     // Trace is from trusted source
+/// }
+/// ```
+pub fn extract_trace_context_safe(
+    message: &Message,
+    sender_agent_name: &str,
+    config: &TelemetryConfig,
+) -> Option<opentelemetry::Context> {
+    if config.reject_untrusted_traces {
+        // If rejecting untrusted traces, we must have a whitelist
+        if config.trusted_trace_sources.is_empty() {
+            tracing::warn!(
+                "Rejecting trace from '{}' - reject_untrusted_traces=true but no trusted sources configured",
+                sender_agent_name
+            );
+            return None;
+        }
+
+        // Check if sender is in whitelist
+        if !config
+            .trusted_trace_sources
+            .contains(sender_agent_name)
+        {
+            tracing::warn!(
+                "Rejecting trace from untrusted source: '{}' (not in whitelist)",
+                sender_agent_name
+            );
+            return None;
+        }
+    }
+
+    extract_trace_context(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use a2a_types::MessageRole;
+
+    fn create_test_message() -> Message {
+        Message {
+            kind: "message".to_string(),
+            message_id: "test-123".to_string(),
+            role: MessageRole::User,
+            parts: vec![],
+            context_id: None,
+            task_id: None,
+            reference_task_ids: vec![],
+            extensions: vec![],
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn test_inject_trace_context() {
+        let message = create_test_message();
+        let message_with_trace = inject_trace_context(message);
+
+        assert!(message_with_trace.metadata.is_some());
+        let metadata = message_with_trace.metadata.unwrap();
+        // Note: traceparent will be present if there's an active span context
+        // In this test environment, it might not be present if no span is active
+        assert!(metadata.contains_key("traceparent") || metadata.is_empty());
+    }
+
+    #[test]
+    fn test_extract_trace_context_no_metadata() {
+        let message = create_test_message();
+        let context = extract_trace_context(&message);
+        assert!(context.is_none());
+    }
+
+    #[test]
+    fn test_extract_trace_context_safe_untrusted() {
+        let config = TelemetryConfig {
+            trusted_trace_sources: ["agent-1".to_string()].iter().cloned().collect(),
+            reject_untrusted_traces: true,
+            ..Default::default()
+        };
+
+        let message = create_test_message();
+        let context = extract_trace_context_safe(&message, "agent-2", &config);
+        assert!(context.is_none()); // agent-2 not in whitelist
+    }
+
+    #[test]
+    fn test_extract_trace_context_safe_trusted() {
+        let config = TelemetryConfig {
+            trusted_trace_sources: ["agent-1".to_string()].iter().cloned().collect(),
+            reject_untrusted_traces: true,
+            ..Default::default()
+        };
+
+        let message = create_test_message();
+        // Even though agent-1 is trusted, there's no trace context in the message
+        let context = extract_trace_context_safe(&message, "agent-1", &config);
+        assert!(context.is_none());
+    }
+
+    #[test]
+    fn test_extract_trace_context_safe_empty_whitelist() {
+        let config = TelemetryConfig {
+            trusted_trace_sources: Default::default(),
+            reject_untrusted_traces: true,
+            ..Default::default()
+        };
+
+        let message = create_test_message();
+        let context = extract_trace_context_safe(&message, "agent-1", &config);
+        assert!(context.is_none()); // Empty whitelist with reject_untrusted_traces = true
+    }
+
+    #[test]
+    fn test_extract_trace_context_safe_permissive() {
+        let config = TelemetryConfig {
+            trusted_trace_sources: Default::default(),
+            reject_untrusted_traces: false, // Accept all
+            ..Default::default()
+        };
+
+        let message = create_test_message();
+        let context = extract_trace_context_safe(&message, "any-agent", &config);
+        // Will be None because there's no trace in the message, not because of trust check
+        assert!(context.is_none());
+    }
+}

--- a/radkit/src/observability/config.rs
+++ b/radkit/src/observability/config.rs
@@ -1,0 +1,210 @@
+//! Configuration types for RadKit observability
+//!
+//! This module provides configuration for telemetry backends, sampling strategies,
+//! and LLM pricing models.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+/// Telemetry backend configuration
+#[derive(Debug, Clone)]
+pub enum TelemetryBackend {
+    /// Telemetry is disabled
+    Disabled,
+
+    /// Use existing global tracer/meter providers (Pattern 4 - for embedded library use)
+    UseGlobal,
+
+    /// Export via OTLP gRPC
+    OtlpGrpc {
+        endpoint: String,
+        timeout: Duration,
+        headers: Vec<(String, String)>,
+    },
+
+    /// Export via OTLP HTTP
+    OtlpHttp {
+        endpoint: String,
+        timeout: Duration,
+        headers: Vec<(String, String)>,
+    },
+
+    /// Output to console (for development)
+    Console,
+}
+
+impl TelemetryBackend {
+    /// Create backend from environment variables
+    pub fn from_env() -> Self {
+        // Check if explicitly disabled
+        if std::env::var("RADKIT_DISABLE_TRACING")
+            .map(|v| v == "1" || v.to_lowercase() == "true")
+            .unwrap_or(false)
+        {
+            return TelemetryBackend::Disabled;
+        }
+
+        // Check for OTLP endpoint
+        if let Ok(endpoint) = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
+            return TelemetryBackend::OtlpGrpc {
+                endpoint,
+                timeout: Duration::from_secs(10),
+                headers: vec![],
+            };
+        }
+
+        // Default to Console in debug builds, Disabled in release
+        #[cfg(debug_assertions)]
+        return TelemetryBackend::Console;
+
+        #[cfg(not(debug_assertions))]
+        return TelemetryBackend::Disabled;
+    }
+
+    /// Check if backend is enabled
+    pub fn is_enabled(&self) -> bool {
+        !matches!(self, TelemetryBackend::Disabled)
+    }
+
+    /// Check if backend uses global providers
+    pub fn uses_global(&self) -> bool {
+        matches!(self, TelemetryBackend::UseGlobal)
+    }
+}
+
+/// Sampling strategy for traces
+#[derive(Debug, Clone)]
+pub enum SamplingStrategy {
+    /// Sample a fixed ratio of traces (0.0 to 1.0)
+    Ratio(f64),
+
+    /// Parent-based sampling with default ratio for root spans
+    ParentBased { default_ratio: f64 },
+
+    /// Different sampling rates for success vs error
+    ErrorBased {
+        success_ratio: f64,
+        error_ratio: f64,
+    },
+
+    /// Always sample (for testing)
+    AlwaysOn,
+
+    /// Never sample
+    AlwaysOff,
+}
+
+/// LLM pricing configuration for cost tracking
+#[derive(Debug, Clone)]
+pub struct LlmPricing {
+    /// Model name/identifier
+    pub model: String,
+
+    /// Price per 1K prompt tokens (USD)
+    pub prompt_price: f64,
+
+    /// Price per 1K completion tokens (USD)
+    pub completion_price: f64,
+}
+
+/// Main telemetry configuration
+#[derive(Debug, Clone)]
+pub struct TelemetryConfig {
+    /// Service name for identification in traces
+    pub service_name: String,
+
+    /// Backend configuration
+    pub backend: TelemetryBackend,
+
+    /// Sampling strategy
+    pub sampling_strategy: SamplingStrategy,
+
+    /// Enable console output in addition to telemetry
+    pub enable_console: bool,
+
+    /// Log level filter
+    pub log_level: String,
+
+    /// Redact PII from traces (hash user IDs, sanitize tool args)
+    pub redact_pii: bool,
+
+    /// Custom LLM pricing (overrides built-in defaults)
+    pub llm_pricing: Vec<LlmPricing>,
+
+    /// Trusted sources for A2A trace propagation
+    pub trusted_trace_sources: HashSet<String>,
+
+    /// Reject traces from untrusted sources
+    pub reject_untrusted_traces: bool,
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        // Read sample rate from environment or default to 10%
+        let sample_rate = std::env::var("RADKIT_TRACE_SAMPLE_RATE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0.1);
+
+        Self {
+            service_name: std::env::var("OTEL_SERVICE_NAME")
+                .unwrap_or_else(|_| "radkit".to_string()),
+            backend: TelemetryBackend::from_env(),
+            sampling_strategy: SamplingStrategy::ParentBased {
+                default_ratio: sample_rate,
+            },
+            enable_console: cfg!(debug_assertions),
+            log_level: std::env::var("RUST_LOG")
+                .unwrap_or_else(|_| "info".to_string()),
+            redact_pii: true,
+            llm_pricing: vec![],
+            trusted_trace_sources: HashSet::new(),
+            reject_untrusted_traces: false,
+        }
+    }
+}
+
+impl TelemetryConfig {
+    /// Check if telemetry is enabled
+    pub fn is_enabled(&self) -> bool {
+        self.backend.is_enabled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_backend_from_env_disabled() {
+        unsafe {
+            std::env::set_var("RADKIT_DISABLE_TRACING", "true");
+        }
+        let backend = TelemetryBackend::from_env();
+        assert!(matches!(backend, TelemetryBackend::Disabled));
+        unsafe {
+            std::env::remove_var("RADKIT_DISABLE_TRACING");
+        }
+    }
+
+    #[test]
+    fn test_backend_is_enabled() {
+        assert!(!TelemetryBackend::Disabled.is_enabled());
+        assert!(TelemetryBackend::Console.is_enabled());
+        assert!(TelemetryBackend::UseGlobal.is_enabled());
+    }
+
+    #[test]
+    fn test_config_default() {
+        let config = TelemetryConfig::default();
+        assert_eq!(config.service_name, "radkit");
+        assert!(config.redact_pii);
+        assert!(!config.reject_untrusted_traces);
+    }
+
+    #[test]
+    fn test_sampling_strategy() {
+        let ratio = SamplingStrategy::Ratio(0.1);
+        assert!(matches!(ratio, SamplingStrategy::Ratio(r) if r == 0.1));
+    }
+}

--- a/radkit/src/observability/metrics.rs
+++ b/radkit/src/observability/metrics.rs
@@ -1,0 +1,178 @@
+//! OpenTelemetry metrics for RadKit
+//!
+//! This module provides metrics instrumentation with graceful degradation.
+//! Metrics work via cached instruments for performance, with fallback to on-demand lookup.
+
+use once_cell::sync::Lazy;
+use opentelemetry::{global, metrics::Counter, KeyValue};
+use std::sync::RwLock;
+
+/// Cached metric instruments for performance
+struct RadkitMetrics {
+    llm_tokens: Counter<u64>,
+    agent_messages: Counter<u64>,
+    tool_executions: Counter<u64>,
+}
+
+/// Global metrics cache
+static METRICS: Lazy<RwLock<Option<RadkitMetrics>>> = Lazy::new(|| RwLock::new(None));
+
+/// Initialize metrics with cached instruments (OPTIONAL - recommended for performance)
+///
+/// Call this AFTER setting up the global meter provider (Pattern 4), or after
+/// calling init_telemetry()/create_telemetry_layer() (Patterns 1-3).
+///
+/// If not called, metrics will still work but with slightly higher overhead
+/// (meter and instrument lookup on each call).
+///
+/// # Example
+/// ```rust,no_run
+/// // Pattern 4 (use-global)
+/// opentelemetry::global::set_meter_provider(parent_meter_provider);
+/// radkit::observability::initialize_metrics();  // Optional but recommended
+///
+/// // Pattern 1 (standalone)
+/// let _guard = radkit::observability::init_telemetry(config)?;
+/// radkit::observability::initialize_metrics();  // Optional but recommended
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn initialize_metrics() {
+    let meter = global::meter("radkit");
+
+    let metrics = RadkitMetrics {
+        llm_tokens: meter
+            .u64_counter("radkit.llm.tokens")
+            .with_description("Total LLM tokens consumed")
+            .init(),
+        agent_messages: meter
+            .u64_counter("radkit.agent.messages")
+            .with_description("Total agent messages processed")
+            .init(),
+        tool_executions: meter
+            .u64_counter("radkit.tool.executions")
+            .with_description("Total tool executions")
+            .init(),
+    };
+
+    if let Ok(mut m) = METRICS.write() {
+        *m = Some(metrics);
+    }
+}
+
+/// Record LLM token usage as metrics
+///
+/// Graceful degradation: works with or without initialize_metrics() call.
+pub fn record_llm_tokens_metric(model: &str, prompt_tokens: u64, completion_tokens: u64) {
+    let total = prompt_tokens + completion_tokens;
+    let attrs = [
+        KeyValue::new("model", model.to_string()),
+        KeyValue::new("token_type", "total"),
+    ];
+
+    // Try cached metrics first (fast path)
+    if let Ok(metrics) = METRICS.read() {
+        if let Some(m) = metrics.as_ref() {
+            m.llm_tokens.add(total, &attrs);
+            return;
+        }
+    }
+
+    // Fallback: get meter on-demand (slower but works without initialization)
+    let meter = global::meter("radkit");
+    let counter = meter
+        .u64_counter("radkit.llm.tokens")
+        .with_description("Total LLM tokens consumed")
+        .init();
+    counter.add(total, &attrs);
+}
+
+/// Record agent message processing
+///
+/// Graceful degradation: works with or without initialize_metrics() call.
+pub fn record_agent_message_metric(agent_name: &str, success: bool) {
+    let attrs = [
+        KeyValue::new("agent", agent_name.to_string()),
+        KeyValue::new("success", success),
+    ];
+
+    // Try cached metrics first (fast path)
+    if let Ok(metrics) = METRICS.read() {
+        if let Some(m) = metrics.as_ref() {
+            m.agent_messages.add(1, &attrs);
+            return;
+        }
+    }
+
+    // Fallback: get meter on-demand
+    let meter = global::meter("radkit");
+    let counter = meter
+        .u64_counter("radkit.agent.messages")
+        .with_description("Total agent messages processed")
+        .init();
+    counter.add(1, &attrs);
+}
+
+/// Record tool execution
+///
+/// Graceful degradation: works with or without initialize_metrics() call.
+pub fn record_tool_execution_metric(tool_name: &str, success: bool) {
+    let attrs = [
+        KeyValue::new("tool", tool_name.to_string()),
+        KeyValue::new("success", success),
+    ];
+
+    // Try cached metrics first (fast path)
+    if let Ok(metrics) = METRICS.read() {
+        if let Some(m) = metrics.as_ref() {
+            m.tool_executions.add(1, &attrs);
+            return;
+        }
+    }
+
+    // Fallback: get meter on-demand
+    let meter = global::meter("radkit");
+    let counter = meter
+        .u64_counter("radkit.tool.executions")
+        .with_description("Total tool executions")
+        .init();
+    counter.add(1, &attrs);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metrics_graceful_degradation() {
+        // This test verifies that metrics work gracefully even without explicit initialization
+        // Simulating Pattern 4 where parent may or may not have set meter provider
+
+        // Call metrics BEFORE initialize_metrics() - should not panic
+        record_llm_tokens_metric("gpt-4", 100, 50);
+        record_agent_message_metric("test-agent", true);
+        record_tool_execution_metric("test-tool", true);
+
+        // Metrics should work (even if they're no-ops due to no meter provider)
+        // The key is: NO PANIC
+
+        // Now initialize metrics (simulating late initialization)
+        initialize_metrics();
+
+        // Metrics should still work after initialization
+        record_llm_tokens_metric("gpt-4", 200, 100);
+
+        // This test documents the behavior:
+        // - Calling metrics before initialization: Works (uses fallback)
+        // - Calling initialize_metrics() after first use: Works (switches to cached)
+        // - No panics, no crashes - graceful degradation
+    }
+
+    #[test]
+    fn test_initialize_metrics_idempotent() {
+        // Multiple calls to initialize_metrics should be safe
+        initialize_metrics();
+        initialize_metrics();
+
+        record_llm_tokens_metric("gpt-4", 100, 50);
+    }
+}

--- a/radkit/src/observability/mod.rs
+++ b/radkit/src/observability/mod.rs
@@ -1,0 +1,95 @@
+//! RadKit Observability
+//!
+//! This module provides comprehensive observability for RadKit using OpenTelemetry.
+//!
+//! # Features
+//! - **4 Integration Patterns**: Standalone, Embedded, Multi-agent, Use-global
+//! - **Distributed Tracing**: W3C Trace Context with parent-based sampling
+//! - **Metrics**: Counters for LLM tokens, messages, and tool executions
+//! - **A2A Trace Propagation**: Automatic trace context across agent boundaries
+//! - **PII Redaction**: GDPR-compliant hashing and sanitization
+//! - **Cost Tracking**: Configurable LLM pricing
+//!
+//! # Quick Start
+//!
+//! ## Pattern 1: RadKit as Main App
+//! ```rust,no_run
+//! use radkit::observability::{TelemetryConfig, init_telemetry};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let _guard = init_telemetry(TelemetryConfig::default())?;
+//!     // Your app logic
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Pattern 2: Embedded Library
+//! ```rust,no_run
+//! use radkit::observability::create_telemetry_layer;
+//! use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let (otel_layer, _guard) = create_telemetry_layer(
+//!         radkit::observability::TelemetryConfig::default()
+//!     )?;
+//!
+//!     tracing_subscriber::registry()
+//!         .with(tracing_subscriber::fmt::layer())
+//!         .with(otel_layer)
+//!         .init();
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Pattern 4: Use Parent's Telemetry
+//! ```rust,no_run
+//! use radkit::observability::{TelemetryConfig, TelemetryBackend, configure_radkit_telemetry};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     // Parent has already set up OpenTelemetry
+//!     configure_radkit_telemetry(TelemetryConfig {
+//!         backend: TelemetryBackend::UseGlobal,
+//!         ..Default::default()
+//!     })?;
+//!
+//!     Ok(())
+//! }
+//! ```
+
+mod a2a_trace;
+mod config;
+mod metrics;
+pub mod semantic_conventions;
+mod telemetry;
+pub mod utils;
+
+// Re-export config types
+pub use config::{LlmPricing, SamplingStrategy, TelemetryBackend, TelemetryConfig};
+
+// Re-export telemetry initialization
+pub use telemetry::{
+    configure_radkit_telemetry, create_telemetry_layer, init_telemetry, ObservabilityError,
+    TelemetryGuard, TelemetryLayerGuard,
+};
+
+// Re-export utility functions
+pub use utils::{
+    calculate_llm_cost, hash_user_id, record_error, record_llm_cost, record_llm_tokens,
+    record_success, sanitize_tool_args,
+};
+
+// Re-export metrics functions
+pub use metrics::{
+    initialize_metrics, record_agent_message_metric, record_llm_tokens_metric,
+    record_tool_execution_metric,
+};
+
+// Re-export A2A trace propagation
+pub use a2a_trace::{extract_trace_context, extract_trace_context_safe, inject_trace_context};
+
+// Re-export semantic conventions for convenience
+pub use semantic_conventions::genai;

--- a/radkit/src/observability/semantic_conventions.rs
+++ b/radkit/src/observability/semantic_conventions.rs
@@ -1,0 +1,99 @@
+//! OpenTelemetry semantic conventions for RadKit
+//!
+//! This module defines standard span names and attributes for observability.
+//! Following GenAI semantic conventions where applicable.
+
+/// GenAI semantic conventions
+pub mod genai {
+    /// Standard span names
+    pub mod span {
+        /// Agent message send operation
+        pub const AGENT_SEND_MESSAGE: &str = "radkit.agent.send_message";
+
+        /// Agent streaming message send operation
+        pub const AGENT_SEND_STREAMING_MESSAGE: &str = "radkit.agent.send_streaming_message";
+
+        /// Core conversation execution loop
+        pub const CONVERSATION_EXECUTE: &str = "radkit.conversation.execute_core";
+
+        /// LLM content generation
+        pub const LLM_GENERATE: &str = "radkit.llm.generate_content";
+
+        /// Tool execution
+        pub const TOOL_EXECUTE: &str = "radkit.tool.execute_call";
+
+        /// Tool batch processing
+        pub const TOOLS_PROCESS: &str = "radkit.tools.process_calls";
+    }
+
+    /// Standard attribute names
+    pub mod attr {
+        // Agent attributes
+        pub const AGENT_NAME: &str = "agent.name";
+        pub const APP_NAME: &str = "app.name";
+        pub const USER_ID: &str = "user.id";
+
+        // LLM attributes
+        pub const LLM_PROVIDER: &str = "llm.provider";
+        pub const LLM_MODEL: &str = "llm.model";
+        pub const LLM_REQUEST_MESSAGES_COUNT: &str = "llm.request.messages_count";
+        pub const LLM_RESPONSE_PROMPT_TOKENS: &str = "llm.response.prompt_tokens";
+        pub const LLM_RESPONSE_COMPLETION_TOKENS: &str = "llm.response.completion_tokens";
+        pub const LLM_RESPONSE_TOTAL_TOKENS: &str = "llm.response.total_tokens";
+        pub const LLM_COST_USD: &str = "llm.cost_usd";
+
+        // Tool attributes
+        pub const TOOL_NAME: &str = "tool.name";
+        pub const TOOL_DURATION_MS: &str = "tool.duration_ms";
+        pub const TOOL_SUCCESS: &str = "tool.success";
+        pub const TOOLS_COUNT: &str = "tools.count";
+        pub const TOOLS_TOTAL_DURATION_MS: &str = "tools.total_duration_ms";
+
+        // Task/iteration attributes
+        pub const TASK_ID: &str = "task.id";
+        pub const ITERATION_COUNT: &str = "iteration.count";
+
+        // OpenTelemetry standard attributes
+        pub const OTEL_KIND: &str = "otel.kind";
+        pub const OTEL_STATUS_CODE: &str = "otel.status_code";
+
+        // Error attributes
+        pub const ERROR_MESSAGE: &str = "error.message";
+
+        // Streaming attribute
+        pub const STREAMING: &str = "streaming";
+    }
+
+    /// Standard span kinds
+    pub mod kind {
+        pub const SERVER: &str = "server";
+        pub const CLIENT: &str = "client";
+        pub const INTERNAL: &str = "internal";
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_span_names() {
+        assert_eq!(genai::span::AGENT_SEND_MESSAGE, "radkit.agent.send_message");
+        assert_eq!(genai::span::LLM_GENERATE, "radkit.llm.generate_content");
+        assert_eq!(genai::span::TOOL_EXECUTE, "radkit.tool.execute_call");
+    }
+
+    #[test]
+    fn test_attribute_names() {
+        assert_eq!(genai::attr::AGENT_NAME, "agent.name");
+        assert_eq!(genai::attr::LLM_PROVIDER, "llm.provider");
+        assert_eq!(genai::attr::TOOL_NAME, "tool.name");
+    }
+
+    #[test]
+    fn test_kind_values() {
+        assert_eq!(genai::kind::SERVER, "server");
+        assert_eq!(genai::kind::CLIENT, "client");
+        assert_eq!(genai::kind::INTERNAL, "internal");
+    }
+}

--- a/radkit/src/observability/telemetry.rs
+++ b/radkit/src/observability/telemetry.rs
@@ -1,0 +1,383 @@
+//! Telemetry initialization for RadKit
+//!
+//! This module provides three initialization patterns:
+//! - Pattern 1: `init_telemetry()` - RadKit as main app
+//! - Pattern 2: `create_telemetry_layer()` - RadKit as embedded library
+//! - Pattern 4: `configure_radkit_telemetry()` - Use existing parent telemetry
+
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::trace::{Sampler, TracerProvider};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::runtime;
+use opentelemetry_otlp::WithExportConfig;
+use tracing_subscriber::Layer;
+
+use crate::observability::config::{SamplingStrategy, TelemetryBackend, TelemetryConfig};
+
+/// Guard for Pattern 1 (standalone app) - manages subscriber lifetime
+pub struct TelemetryGuard {
+    _tracer_provider: Option<TracerProvider>,
+}
+
+impl Drop for TelemetryGuard {
+    fn drop(&mut self) {
+        //   WARNING: This can block indefinitely if OTLP endpoint is unreachable
+        //
+        // OpenTelemetry's shutdown_tracer_provider() tries to flush all pending spans
+        // to the configured backend. If the backend is down or network is slow, this
+        // can hang.
+        //
+        // Mitigation options:
+        // 1. Set reasonable OTLP timeout in config (recommended: 10s max)
+        // 2. Use tokio::time::timeout() in your application shutdown logic
+        // 3. Accept that shutdown may be slow in degraded network conditions
+        //
+        // For production apps, wrap shutdown in timeout:
+        // tokio::time::timeout(Duration::from_secs(30), async { drop(guard) }).await
+        opentelemetry::global::shutdown_tracer_provider();
+    }
+}
+
+/// Guard for Pattern 2 (embedded library) - manages tracer provider lifetime
+pub struct TelemetryLayerGuard {
+    _tracer_provider: Option<TracerProvider>,
+}
+
+impl Drop for TelemetryLayerGuard {
+    fn drop(&mut self) {
+        // Provider's Drop impl handles shutdown
+    }
+}
+
+/// Error types for observability operations
+#[derive(Debug, thiserror::Error)]
+pub enum ObservabilityError {
+    #[error("Telemetry is disabled")]
+    Disabled,
+
+    #[error("Global subscriber already initialized")]
+    AlreadyInitialized,
+
+    #[error("OpenTelemetry error: {0}")]
+    OpenTelemetry(#[from] opentelemetry::trace::TraceError),
+
+    #[error("Configuration error: {0}")]
+    Config(String),
+}
+
+/// Pattern 1: Initialize telemetry for standalone applications
+///
+/// RadKit manages the global subscriber. Use this when RadKit is your main application.
+///
+/// # Example
+/// ```rust,no_run
+/// use radkit::observability::{TelemetryConfig, init_telemetry};
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     // IMPORTANT: Keep this guard alive!
+///     let _telemetry_guard = match init_telemetry(TelemetryConfig::default()) {
+///         Ok(guard) => {
+///             tracing::info!(" Observability initialized successfully");
+///             Some(guard)
+///         }
+///         Err(e) => {
+///             eprintln!("  WARNING: Failed to initialize observability: {}", e);
+///             eprintln!("    Application will continue WITHOUT observability");
+///             None  // Graceful degradation - app continues working
+///         }
+///     };
+///
+///     // Your app logic here
+///     Ok(())
+/// }
+/// ```
+pub fn init_telemetry(config: TelemetryConfig) -> Result<TelemetryGuard, ObservabilityError> {
+    let (tracer, tracer_provider) = if config.is_enabled() {
+        let (t, p) = create_tracer_global(&config)?;
+        (Some(t), p) // p is already Option<TracerProvider>
+    } else {
+        (None, None)
+    };
+
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(&config.log_level));
+
+    let otel_layer = tracer.map(|t| tracing_opentelemetry::layer().with_tracer(t));
+
+    let fmt_layer = if config.enable_console {
+        Some(
+            tracing_subscriber::fmt::layer()
+                .with_target(false)
+                .compact(),
+        )
+    } else {
+        None
+    };
+
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(otel_layer)
+        .with(fmt_layer)
+        .try_init()
+        .map_err(|_| ObservabilityError::AlreadyInitialized)?;
+
+    Ok(TelemetryGuard {
+        _tracer_provider: tracer_provider,
+    })
+}
+
+/// Pattern 2: Create telemetry layer for embedded library use
+///
+/// Parent application controls the subscriber. Use this when RadKit is embedded in a larger system.
+///
+/// # Example
+/// ```rust,no_run
+/// use radkit::observability::{TelemetryConfig, create_telemetry_layer};
+/// use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     // Parent controls subscriber
+///     let (otel_layer, _otel_guard) = create_telemetry_layer(
+///         TelemetryConfig::default()
+///     )?;
+///
+///     tracing_subscriber::registry()
+///         .with(tracing_subscriber::fmt::layer())
+///         .with(otel_layer)
+///         .init();
+///
+///     Ok(())
+/// }
+/// ```
+pub fn create_telemetry_layer<S>(
+    config: TelemetryConfig,
+) -> Result<(Option<impl Layer<S>>, Option<TelemetryLayerGuard>), ObservabilityError>
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    if !config.is_enabled() {
+        return Ok((None, None));
+    }
+
+    let (tracer, tracer_provider) = create_tracer_local(&config)?;
+
+    let guard = TelemetryLayerGuard {
+        _tracer_provider: tracer_provider, // Already Option<TracerProvider>
+    };
+
+    let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    Ok((Some(layer), Some(guard)))
+}
+
+/// Pattern 4: Configure RadKit to use existing global telemetry
+///
+/// Use this when parent application has already set up OpenTelemetry.
+/// RadKit will use the global tracer provider and respect parent's configuration.
+///
+/// # Example
+/// ```rust,no_run
+/// use radkit::observability::{TelemetryConfig, TelemetryBackend, configure_radkit_telemetry};
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     // Parent already set up OpenTelemetry
+///     // opentelemetry::global::set_tracer_provider(parent_tracer_provider);
+///
+///     // RadKit uses global tracer, just configure preferences
+///     configure_radkit_telemetry(TelemetryConfig {
+///         service_name: "radkit-component".to_string(),
+///         backend: TelemetryBackend::UseGlobal,
+///         redact_pii: true,
+///         ..Default::default()
+///     })?;
+///
+///     Ok(())
+/// }
+/// ```
+pub fn configure_radkit_telemetry(config: TelemetryConfig) -> Result<(), ObservabilityError> {
+    // Store config globally for PII redaction, pricing, and other preferences
+    crate::observability::utils::set_global_config(config);
+    Ok(())
+}
+
+/// Create tracer and set it as global (for Pattern 1)
+fn create_tracer_global(
+    config: &TelemetryConfig,
+) -> Result<(opentelemetry_sdk::trace::Tracer, Option<TracerProvider>), ObservabilityError> {
+    let (tracer, provider) = create_tracer_impl(config)?;
+    // Only set global provider if we created one (not for UseGlobal)
+    if let Some(ref p) = provider {
+        opentelemetry::global::set_tracer_provider(p.clone());
+    }
+    Ok((tracer, provider))
+}
+
+/// Create tracer without setting global (for Pattern 2)
+fn create_tracer_local(
+    config: &TelemetryConfig,
+) -> Result<(opentelemetry_sdk::trace::Tracer, Option<TracerProvider>), ObservabilityError> {
+    create_tracer_impl(config)
+}
+
+/// Core tracer creation implementation
+fn create_tracer_impl(
+    config: &TelemetryConfig,
+) -> Result<(opentelemetry_sdk::trace::Tracer, Option<TracerProvider>), ObservabilityError> {
+    if !config.is_enabled() {
+        return Err(ObservabilityError::Disabled);
+    }
+
+    let resource = Resource::new(vec![
+        KeyValue::new("service.name", config.service_name.clone()),
+        KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
+    ]);
+
+    let sampler = match &config.sampling_strategy {
+        SamplingStrategy::Ratio(r) => Sampler::TraceIdRatioBased(*r),
+        SamplingStrategy::ParentBased { default_ratio } => {
+            Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(*default_ratio)))
+        }
+        SamplingStrategy::AlwaysOn => Sampler::AlwaysOn,
+        SamplingStrategy::AlwaysOff => Sampler::AlwaysOff,
+        SamplingStrategy::ErrorBased { success_ratio, .. } => {
+            // For now, use success_ratio as default
+            // Could implement custom sampler for full error-based logic
+            Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(*success_ratio)))
+        }
+    };
+
+    match &config.backend {
+        TelemetryBackend::Disabled => return Err(ObservabilityError::Disabled),
+
+        TelemetryBackend::UseGlobal => {
+            // Use existing global tracer provider
+            // We need to create a local provider that wraps the global one
+            use opentelemetry::trace::TracerProvider as _;
+            let provider = TracerProvider::builder().build();
+            let tracer = provider.tracer(config.service_name.clone());
+            return Ok((tracer, None));
+        }
+
+        TelemetryBackend::OtlpGrpc {
+            endpoint,
+            timeout,
+            headers,
+        } => {
+            let mut exporter = opentelemetry_otlp::new_exporter()
+                .tonic()
+                .with_endpoint(endpoint)
+                .with_timeout(*timeout);
+
+            if !headers.is_empty() {
+                let mut metadata = tonic::metadata::MetadataMap::new();
+                for (k, v) in headers.iter() {
+                    if let (Ok(key), Ok(value)) = (
+                        k.parse::<tonic::metadata::MetadataKey<_>>(),
+                        v.parse::<tonic::metadata::MetadataValue<_>>(),
+                    ) {
+                        metadata.insert(key, value);
+                    }
+                }
+                exporter = exporter.with_metadata(metadata);
+            }
+
+            let tracer = opentelemetry_otlp::new_pipeline()
+                .tracing()
+                .with_exporter(exporter)
+                .with_trace_config(
+                    opentelemetry_sdk::trace::Config::default()
+                        .with_sampler(sampler.clone())
+                        .with_resource(resource.clone())
+                        .with_max_events_per_span(32)
+                        .with_max_attributes_per_span(128),
+                )
+                .install_batch(runtime::Tokio)?;
+
+            // Note: install_batch() returns Tracer directly and manages provider globally
+            Ok((tracer, None))
+        }
+
+        TelemetryBackend::OtlpHttp {
+            endpoint,
+            timeout,
+            headers,
+        } => {
+            let mut exporter = opentelemetry_otlp::new_exporter()
+                .http()
+                .with_endpoint(endpoint)
+                .with_timeout(*timeout);
+
+            if !headers.is_empty() {
+                let headers_map: std::collections::HashMap<String, String> = headers
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                exporter = exporter.with_headers(headers_map);
+            }
+
+            let tracer = opentelemetry_otlp::new_pipeline()
+                .tracing()
+                .with_exporter(exporter)
+                .with_trace_config(
+                    opentelemetry_sdk::trace::Config::default()
+                        .with_sampler(sampler.clone())
+                        .with_resource(resource.clone())
+                        .with_max_events_per_span(32)
+                        .with_max_attributes_per_span(128),
+                )
+                .install_batch(runtime::Tokio)?;
+
+            // Note: install_batch() returns Tracer directly and manages provider globally
+            Ok((tracer, None))
+        }
+
+        TelemetryBackend::Console => {
+            use opentelemetry::trace::TracerProvider as _;
+
+            let tracer_provider = TracerProvider::builder()
+                .with_simple_exporter(opentelemetry_stdout::SpanExporter::default())
+                .with_config(
+                    opentelemetry_sdk::trace::Config::default()
+                        .with_sampler(sampler)
+                        .with_resource(resource),
+                )
+                .build();
+
+            let tracer = tracer_provider.tracer(config.service_name.clone());
+            Ok((tracer, Some(tracer_provider)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_disabled_backend() {
+        let config = TelemetryConfig {
+            backend: TelemetryBackend::Disabled,
+            ..Default::default()
+        };
+
+        let result = create_tracer_impl(&config);
+        assert!(matches!(result, Err(ObservabilityError::Disabled)));
+    }
+
+    #[test]
+    fn test_configure_radkit_telemetry() {
+        let config = TelemetryConfig {
+            backend: TelemetryBackend::UseGlobal,
+            ..Default::default()
+        };
+
+        let result = configure_radkit_telemetry(config);
+        assert!(result.is_ok());
+    }
+}

--- a/radkit/src/observability/utils.rs
+++ b/radkit/src/observability/utils.rs
@@ -1,0 +1,223 @@
+//! Utility functions for observability
+//!
+//! This module provides utilities for PII redaction, cost calculation,
+//! and span recording helpers.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use sha2::{Digest, Sha256};
+use std::sync::RwLock;
+use tracing::Span;
+
+use crate::observability::config::TelemetryConfig;
+
+/// Global configuration storage for Pattern 4 (use-global mode)
+/// Single source of truth - no duplicate storage
+static GLOBAL_CONFIG: Lazy<RwLock<Option<TelemetryConfig>>> = Lazy::new(|| RwLock::new(None));
+
+/// Hash user ID for GDPR compliance
+///
+/// Uses SHA256 to create a deterministic, anonymized identifier.
+/// Returns first 16 characters of hex-encoded hash.
+pub fn hash_user_id(user_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(user_id.as_bytes());
+    format!("{:x}", hasher.finalize())[..16].to_string()
+}
+
+/// Sanitize tool arguments to remove sensitive information
+///
+/// Redacts API keys, tokens, passwords, and authorization headers.
+/// Also truncates to max_length to prevent excessive trace sizes.
+pub fn sanitize_tool_args(args: &str, max_length: usize) -> String {
+    static SENSITIVE_PATTERNS: Lazy<Vec<(Regex, &'static str)>> = Lazy::new(|| {
+        vec![
+            (
+                Regex::new(r#"["']?(api[_-]?key|token|password)["']?\s*[:=]\s*['"]?[^'"]+['"]?"#)
+                    .expect("Failed to compile regex"),
+                "$1: [REDACTED]",
+            ),
+            (
+                Regex::new(r"(?i)(authorization|bearer)\s*:\s*.+")
+                    .expect("Failed to compile regex"),
+                "$1: [REDACTED]",
+            ),
+        ]
+    });
+
+    let mut sanitized = args.to_string();
+    for (re, replacement) in SENSITIVE_PATTERNS.iter() {
+        sanitized = re.replace_all(&sanitized, *replacement).to_string();
+    }
+
+    if sanitized.len() > max_length {
+        sanitized = format!("{}...[truncated]", &sanitized[..max_length]);
+    }
+
+    sanitized
+}
+
+/// Record LLM token usage on current span
+pub fn record_llm_tokens(prompt_tokens: u64, completion_tokens: u64, total_tokens: u64) {
+    let span = Span::current();
+    span.record("llm.response.prompt_tokens", prompt_tokens);
+    span.record("llm.response.completion_tokens", completion_tokens);
+    span.record("llm.response.total_tokens", total_tokens);
+}
+
+/// Calculate LLM cost with configurable pricing
+///
+/// First checks custom pricing from global config, then falls back to built-in defaults.
+/// Returns cost in USD.
+pub fn calculate_llm_cost(model: &str, prompt_tokens: u64, completion_tokens: u64) -> f64 {
+    // Check custom pricing from global config (single source of truth)
+    if let Ok(config) = GLOBAL_CONFIG.read() {
+        if let Some(cfg) = config.as_ref() {
+            if let Some(custom) = cfg.llm_pricing.iter().find(|p| p.model == model) {
+                return (prompt_tokens as f64 * custom.prompt_price / 1000.0)
+                    + (completion_tokens as f64 * custom.completion_price / 1000.0);
+            }
+        }
+    }
+
+    // Fall back to built-in defaults (prices per 1K tokens in USD)
+    let (prompt_price, completion_price) = match model {
+        // OpenAI GPT-4
+        "gpt-4" | "gpt-4-0613" => (0.03, 0.06),
+        "gpt-4-32k" => (0.06, 0.12),
+        "gpt-4-turbo" | "gpt-4-turbo-preview" => (0.01, 0.03),
+        "gpt-4o" | "gpt-4o-2024-05-13" => (0.005, 0.015),
+        "gpt-4o-mini" => (0.00015, 0.0006),
+
+        // OpenAI GPT-3.5
+        "gpt-3.5-turbo" | "gpt-3.5-turbo-0125" => (0.0005, 0.0015),
+
+        // Anthropic Claude
+        "claude-3-opus-20240229" => (0.015, 0.075),
+        "claude-3-sonnet-20240229" => (0.003, 0.015),
+        "claude-3-haiku-20240307" => (0.00025, 0.00125),
+        "claude-3-5-sonnet-20240620" => (0.003, 0.015),
+
+        // Google Gemini
+        "gemini-1.5-pro" => (0.00125, 0.005),
+        "gemini-1.5-flash" => (0.000075, 0.0003),
+
+        _ => {
+            tracing::warn!("Unknown LLM model '{}' - cost will be $0.00", model);
+            (0.0, 0.0)
+        }
+    };
+
+    (prompt_tokens as f64 * prompt_price / 1000.0)
+        + (completion_tokens as f64 * completion_price / 1000.0)
+}
+
+/// Record LLM cost on current span
+pub fn record_llm_cost(model: &str, prompt_tokens: u64, completion_tokens: u64) {
+    let cost = calculate_llm_cost(model, prompt_tokens, completion_tokens);
+    Span::current().record("llm.cost_usd", cost);
+}
+
+/// Record error on current span
+pub fn record_error(error: &dyn std::error::Error) {
+    let span = Span::current();
+    span.record("otel.status_code", "ERROR");
+    span.record("error.message", error.to_string().as_str());
+}
+
+/// Record success on current span
+pub fn record_success() {
+    let span = Span::current();
+    span.record("otel.status_code", "OK");
+}
+
+/// Record agent message metric
+pub fn record_agent_message_metric(agent_name: &str, success: bool) {
+    crate::observability::metrics::record_agent_message_metric(agent_name, success);
+}
+
+/// Record LLM token usage metric
+pub fn record_llm_tokens_metric(model: &str, prompt_tokens: u64, completion_tokens: u64) {
+    crate::observability::metrics::record_llm_tokens_metric(model, prompt_tokens, completion_tokens);
+}
+
+/// Record tool execution metric
+pub fn record_tool_execution_metric(tool_name: &str, success: bool) {
+    crate::observability::metrics::record_tool_execution_metric(tool_name, success);
+}
+
+/// Store global config for Pattern 4 (use-global mode)
+///
+/// This is called by `configure_radkit_telemetry()` to store configuration
+/// that can be accessed by utility functions.
+pub(crate) fn set_global_config(config: TelemetryConfig) {
+    if let Ok(mut cfg) = GLOBAL_CONFIG.write() {
+        *cfg = Some(config);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_user_id_deterministic() {
+        let hash1 = hash_user_id("user@example.com");
+        let hash2 = hash_user_id("user@example.com");
+        assert_eq!(hash1, hash2);
+        assert_eq!(hash1.len(), 16);
+    }
+
+    #[test]
+    fn test_hash_user_id_different_inputs() {
+        let hash1 = hash_user_id("user1@example.com");
+        let hash2 = hash_user_id("user2@example.com");
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_sanitize_tool_args_api_key() {
+        let input = r#"{"api_key": "sk-1234567890abcdef"}"#;
+        let sanitized = sanitize_tool_args(input, 1000);
+        assert!(sanitized.contains("[REDACTED]"));
+        assert!(!sanitized.contains("sk-1234567890abcdef"));
+    }
+
+    #[test]
+    fn test_sanitize_tool_args_bearer_token() {
+        let input = "Authorization: Bearer abc123xyz";
+        let sanitized = sanitize_tool_args(input, 1000);
+        assert!(sanitized.contains("[REDACTED]"));
+        assert!(!sanitized.contains("abc123xyz"));
+    }
+
+    #[test]
+    fn test_sanitize_tool_args_truncation() {
+        let input = "a".repeat(200);
+        let sanitized = sanitize_tool_args(&input, 100);
+        assert!(sanitized.contains("[truncated]"));
+        assert!(sanitized.len() <= 115); // 100 + "[truncated]"
+    }
+
+    #[test]
+    fn test_calculate_llm_cost_gpt4() {
+        let cost = calculate_llm_cost("gpt-4", 1000, 500);
+        // $0.03/1K prompt + $0.06/1K completion
+        let expected = (1000.0 * 0.03 / 1000.0) + (500.0 * 0.06 / 1000.0);
+        assert!((cost - expected).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_calculate_llm_cost_claude() {
+        let cost = calculate_llm_cost("claude-3-opus-20240229", 2000, 1000);
+        // $0.015/1K prompt + $0.075/1K completion
+        let expected = (2000.0 * 0.015 / 1000.0) + (1000.0 * 0.075 / 1000.0);
+        assert!((cost - expected).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_calculate_llm_cost_unknown_model() {
+        let cost = calculate_llm_cost("unknown-model", 1000, 500);
+        assert_eq!(cost, 0.0);
+    }
+}


### PR DESCRIPTION
Implements native OpenTelemetry support with distributed tracing, metrics, and comprehensive instrumentation across the RadKit framework.

  ## New Features

  ### Observability Module (`radkit/src/observability/`)
  - **Telemetry Initialization**: 4 integration patterns (standalone, embedded,
    multi-agent, UseGlobal)
  - **Distributed Tracing**: W3C trace context propagation with A2A protocol
  - **Metrics**: Agent messages, LLM tokens, and tool execution tracking
  - **Security**: PII redaction (SHA256 user ID hashing), sensitive data sanitization
  - **Cost Tracking**: Configurable LLM pricing with built-in defaults

  ### Instrumentation
  - **Agent Level**: `send_message` and `send_streaming_message` instrumented
  - **Conversation Loop**: Full execution tracing with iteration counts
  - **LLM Providers**: All 3 providers (Anthropic, Gemini, Mock) instrumented
  - **Tool Execution**: Individual tool spans with duration and success metrics

  ### Documentation
  - Updated root README with observability overview and Pattern 4 example
  - Added comprehensive observability section to `radkit/README.md`
  - Enhanced `radkit-axum/README.md` with trace propagation guide
  - Added complete working example: `radkit-axum/examples/observability_server.rs`

  ## Dependencies
  - opentelemetry 0.22
  - opentelemetry_sdk 0.22 (with rt-tokio)
  - opentelemetry-otlp 0.15 (with tokio, grpc-tonic)
  - tracing-opentelemetry 0.23

  ## Testing
  - 25 observability unit tests (config, metrics, trace propagation, PII)
  - 18 agent tests updated and passing
  - Full workspace compilation verified
